### PR TITLE
Add quarantined file extractor and tests

### DIFF
--- a/synchronoss_parser/collect_quarantined_files.py
+++ b/synchronoss_parser/collect_quarantined_files.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Extract quarantined zip files fixing missing or wrong extensions."""
+from __future__ import annotations
+
+from pathlib import Path
+import zipfile
+import imghdr
+from typing import Iterable, List, Tuple
+
+from .collect_media import ensure_unique_name
+
+
+def _guess_extension(data: bytes, original_suffix: str = "") -> str:
+    """Guess file extension based on file signature.
+
+    Falls back to ``original_suffix`` if type cannot be determined.
+    """
+    kind = imghdr.what(None, data)
+    if kind:
+        if kind == "jpeg":
+            return ".jpg"
+        return f".{kind}"
+    if data.startswith(b"%PDF"):
+        return ".pdf"
+    try:
+        data.decode("utf-8")
+        return ".txt"
+    except Exception:
+        pass
+    return original_suffix
+
+
+def collect_quarantined_files(
+    archives: Iterable[Path], compiled_path: Path
+) -> Tuple[List[Path], List[str]]:
+    """Extract files from ``archives`` into ``compiled_path``.
+
+    Files inside archives with missing or wrong extensions will be written
+    using the extension guessed from their contents. Duplicate file names are
+    resolved using :func:`ensure_unique_name`.
+
+    Parameters
+    ----------
+    archives: Iterable[Path]
+        Paths to ``.zip`` files (possibly with non-standard extensions).
+    compiled_path: Path
+        Destination directory for extracted files.
+
+    Returns
+    -------
+    Tuple[List[Path], List[str]]
+        A tuple of ``(outputs, errors)`` where ``outputs`` is the list of
+        extracted file paths and ``errors`` contains error messages for any
+        archives that could not be processed.
+    """
+    compiled_path.mkdir(exist_ok=True)
+    outputs: List[Path] = []
+    errors: List[str] = []
+
+    for archive in archives:
+        try:
+            if not zipfile.is_zipfile(archive):
+                errors.append(f"{archive} is not a zip file")
+                continue
+            with zipfile.ZipFile(archive) as zf:
+                for info in zf.infolist():
+                    if info.is_dir():
+                        continue
+                    data = zf.read(info)
+                    orig_suffix = Path(info.filename).suffix
+                    ext = _guess_extension(data, orig_suffix)
+                    name = Path(info.filename).stem + ext
+                    dest = ensure_unique_name(compiled_path, name)
+                    dest.write_bytes(data)
+                    outputs.append(dest)
+        except Exception as exc:
+            errors.append(f"{archive}: {exc}")
+    return outputs, errors
+
+
+__all__ = ["collect_quarantined_files"]

--- a/tests/test_collect_quarantined_files.py
+++ b/tests/test_collect_quarantined_files.py
@@ -1,0 +1,49 @@
+import importlib
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+def load_module():
+    project_root = Path(__file__).resolve().parents[1]
+    sys.path.append(str(project_root))
+    return importlib.import_module("synchronoss_parser.collect_quarantined_files")
+
+
+def _png_bytes(color: str) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (1, 1), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_collect_quarantined_files_handles_missing_and_wrong_extensions(tmp_path):
+    module = load_module()
+
+    # Create sample archives with files lacking or having wrong extensions
+    archive1 = tmp_path / "sample.zip_file_1"
+    with zipfile.ZipFile(archive1, "w") as zf:
+        zf.writestr("image", _png_bytes("red"))
+        zf.writestr("image_wrong.txt", _png_bytes("blue"))
+
+    archive2 = tmp_path / "sample2.zip_file_1"
+    with zipfile.ZipFile(archive2, "w") as zf:
+        zf.writestr("image", _png_bytes("green"))
+
+    not_zip = tmp_path / "notzip.zip_file_1"
+    not_zip.write_text("not a zip archive")
+
+    output_dir = tmp_path / "compiled"
+    outputs, errors = module.collect_quarantined_files([archive1, archive2, not_zip], output_dir)
+
+    names = sorted(p.name for p in outputs)
+    assert names == ["image.png", "image_1.png", "image_wrong.png"]
+    assert sorted(f.name for f in output_dir.iterdir()) == names
+
+    for p in outputs:
+        assert p.suffix == ".png"
+
+    assert any("notzip.zip_file_1" in e for e in errors)


### PR DESCRIPTION
## Summary
- implement `collect_quarantined_files` utility to unpack quarantined archives, fix missing extensions, and avoid name collisions
- add tests ensuring proper extraction, extension correction, duplicate resolution, and error handling for invalid archives

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8637bb888324834936b3f0bc9551