### PR TITLE
Add contact-aware attachment collection

### DIFF
--- a/synchronoss_parser/toolbox_gui.py
+++ b/synchronoss_parser/toolbox_gui.py
@@ -65,6 +65,14 @@ def build_collect_media_tab(nb: ttk.Notebook) -> None:
         if path:
             out_var.set(path)
 
+    def browse_contacts() -> None:
+        path = filedialog.askopenfilename(
+            title="Select contacts Excel file",
+            filetypes=[("Excel files", "*.xlsx"), ("All files", "*.*")],
+        )
+        if path:
+            contacts_var.set(path)
+
     def run() -> None:
         progress.start()
 
@@ -131,12 +139,22 @@ def build_collect_media_tab(nb: ttk.Notebook) -> None:
         row=1, column=2, padx=5, pady=5
     )
 
-    ttk.Button(frame, text="Run", command=run).grid(row=2, column=1, pady=10)
+    ttk.Label(frame, text="Contacts file:").grid(
+        row=2, column=0, sticky="e", padx=5, pady=5
+    )
+    ttk.Entry(frame, textvariable=contacts_var, width=50).grid(
+        row=2, column=1, padx=5, pady=5
+    )
+    ttk.Button(frame, text="Browse", command=browse_contacts).grid(
+        row=2, column=2, padx=5, pady=5
+    )
 
-    progress.grid(row=3, column=0, columnspan=3, sticky="ew", padx=5)
+    ttk.Button(frame, text="Run", command=run).grid(row=3, column=1, pady=10)
+
+    progress.grid(row=4, column=0, columnspan=3, sticky="ew", padx=5)
 
     ttk.Label(frame, textvariable=status_var, wraplength=400, justify="left").grid(
-        row=4, column=0, columnspan=3, padx=5, pady=5
+        row=5, column=0, columnspan=3, padx=5, pady=5
     )
 
 
@@ -339,6 +357,7 @@ def build_collect_attachments_tab(nb: ttk.Notebook) -> None:
 
     attachments_var = tk.StringVar()
     out_var = tk.StringVar()
+    contacts_var = tk.StringVar()
     status_var = tk.StringVar()
     progress = ttk.Progressbar(frame, mode="indeterminate")
 
@@ -351,6 +370,14 @@ def build_collect_attachments_tab(nb: ttk.Notebook) -> None:
         path = filedialog.askdirectory(initialdir=out_var.get() or ".")
         if path:
             out_var.set(path)
+
+    def browse_contacts() -> None:
+        path = filedialog.askopenfilename(
+            title="Select contacts Excel file",
+            filetypes=[("Excel files", "*.xlsx"), ("All files", "*.*")],
+        )
+        if path:
+            contacts_var.set(path)
 
     def run() -> None:
         progress.start()
@@ -390,9 +417,10 @@ def build_collect_attachments_tab(nb: ttk.Notebook) -> None:
                 / "compiled_attachment_log"
                 / "compiled_attachment_log.xlsx"
             )
+            contacts_path = contacts_var.get() or None
             try:
                 records, exif_keys = ca.collect_attachments(
-                    attachments_root, compiled_path
+                    attachments_root, compiled_path, contacts_path
                 )
                 ca.write_excel(records, exif_keys, logfile)
                 msg = (
@@ -426,12 +454,22 @@ def build_collect_attachments_tab(nb: ttk.Notebook) -> None:
         row=1, column=2, padx=5, pady=5
     )
 
-    ttk.Button(frame, text="Run", command=run).grid(row=2, column=1, pady=10)
+    ttk.Label(frame, text="Contacts file:").grid(
+        row=2, column=0, sticky="e", padx=5, pady=5
+    )
+    ttk.Entry(frame, textvariable=contacts_var, width=50).grid(
+        row=2, column=1, padx=5, pady=5
+    )
+    ttk.Button(frame, text="Browse", command=browse_contacts).grid(
+        row=2, column=2, padx=5, pady=5
+    )
 
-    progress.grid(row=3, column=0, columnspan=3, sticky="ew", padx=5)
+    ttk.Button(frame, text="Run", command=run).grid(row=3, column=1, pady=10)
+
+    progress.grid(row=4, column=0, columnspan=3, sticky="ew", padx=5)
 
     ttk.Label(frame, textvariable=status_var, wraplength=400, justify="left").grid(
-        row=4, column=0, columnspan=3, padx=5, pady=5
+        row=5, column=0, columnspan=3, padx=5, pady=5
     )
 
 

--- a/tests/test_collect_attachments.py
+++ b/tests/test_collect_attachments.py
@@ -3,6 +3,7 @@ import hashlib
 import sys
 from pathlib import Path
 
+import pandas as pd
 from PIL import Image
 from openpyxl import load_workbook
 
@@ -30,19 +31,34 @@ def test_collect_attachments_copies_files_and_logs_metadata(tmp_path):
     img2_path = attachments_dir / "photo2.png"
     img2.save(img2_path)
 
+    # Contacts lookup mapping numbers to names
+    df = pd.DataFrame(
+        [
+            {"firstname": "Alice", "lastname": "Smith", "phone_numbers": "111"},
+            {"firstname": "Bob", "lastname": "Jones", "phone_numbers": "222"},
+        ]
+    )
+    contacts_xlsx = tmp_path / "contacts.xlsx"
+    df.to_excel(contacts_xlsx, index=False)
+
     csv_content = (
         "Date,Type,Direction,Attachments,Body,Sender,Recipients,\"Message ID\"\n"
-        "2024-01-01T00:00:00Z,mms,in,photo1.jpg|photo2.png,Hi,Alice,Bob,id1\n"
+        "2024-01-01T00:00:00Z,mms,in,photo1.jpg|photo2.png,Hi,111,222,id1\n"
     )
     (messages_dir / "20240101.csv").write_text(csv_content)
 
     compiled = tmp_path / "Compiled Attachments"
-    records, exif_keys = collect_attachments.collect_attachments(messages_dir / "attachments", compiled)
+    records, exif_keys = collect_attachments.collect_attachments(
+        messages_dir / "attachments", compiled, contacts_xlsx
+    )
     logfile = compiled / "log.xlsx"
     collect_attachments.write_excel(records, exif_keys, logfile)
 
     dest_files = {f.name for f in compiled.iterdir() if f.is_file() and f.name != "log.xlsx"}
-    assert dest_files == {"photo1.jpg", "photo2.png"}
+    expected_files = {r["File Name"] for r in records}
+    assert dest_files == expected_files
+    for name in expected_files:
+        assert name.startswith("Alice Smith - 2024-01-01 00-00-00")
 
     md5_1 = hashlib.md5(img1_path.read_bytes()).hexdigest()
     md5_2 = hashlib.md5(img2_path.read_bytes()).hexdigest()
@@ -52,67 +68,54 @@ def test_collect_attachments_copies_files_and_logs_metadata(tmp_path):
     headers = [cell.value for cell in ws[1]]
     assert headers[:5] == ["File Name", "Date", "Sender", "Recipient", "MD5"]
     assert "Orientation" in headers
-    col_map = {h: i + 1 for i, h in enumerate(headers)}
 
     rows = {}
     for r in ws.iter_rows(min_row=2, values_only=True):
         row_data = dict(zip(headers, r))
         rows[row_data["File Name"]] = row_data
 
-    assert set(rows.keys()) == {"photo1.jpg", "photo2.png"}
+    assert set(rows.keys()) == expected_files
 
-    row1 = rows["photo1.jpg"]
-    assert row1["Date"] == "2024-01-01T00:00:00Z"
-    assert row1["Sender"] == "Alice"
-    assert row1["Recipient"] == "Bob"
-    assert row1["MD5"] == md5_1
-    assert row1["Orientation"] == 1
+    row_jpg = next(v for k, v in rows.items() if k.endswith(".jpg"))
+    assert row_jpg["Date"] == "2024-01-01T00:00:00Z"
+    assert row_jpg["Sender"] == "Alice Smith"
+    assert row_jpg["Recipient"] == "Bob Jones"
+    assert row_jpg["MD5"] == md5_1
+    assert row_jpg["Orientation"] == 1
 
-    row2 = rows["photo2.png"]
-    assert row2["MD5"] == md5_2
-    assert row2["Sender"] == "Alice"
-    assert row2["Recipient"] == "Bob"
-    assert row2.get("Orientation") in ("", None)
+    row_png = next(v for k, v in rows.items() if k.endswith(".png"))
+    assert row_png["MD5"] == md5_2
+    assert row_png["Sender"] == "Alice Smith"
+    assert row_png["Recipient"] == "Bob Jones"
+    assert row_png.get("Orientation") in ("", None)
 
 
-def test_duplicate_filenames_different_contexts(tmp_path):
+def test_duplicate_filenames_same_message(tmp_path):
     collect_attachments = load_module()
 
     messages_dir = tmp_path / "messages"
     messages_dir.mkdir()
 
-    # First attachment
-    dir1 = messages_dir / "attachments" / "mms" / "in" / "2024-01-01"
-    dir1.mkdir(parents=True)
+    attachments_dir = messages_dir / "attachments" / "mms" / "in" / "2024-01-01"
+    attachments_dir.mkdir(parents=True)
     img1 = Image.new("RGB", (10, 10), color="red")
-    img1_path = dir1 / "sample.png"
-    img1.save(img1_path)
-
-    # Second attachment with same filename in different folder
-    dir2 = messages_dir / "attachments" / "sms" / "out" / "2024-01-02"
-    dir2.mkdir(parents=True)
+    img1.save(attachments_dir / "a.jpg")
     img2 = Image.new("RGB", (10, 10), color="blue")
-    img2_path = dir2 / "sample.png"
-    img2.save(img2_path)
+    img2.save(attachments_dir / "b.jpg")
 
-    csv1 = (
+    csv = (
         "Date,Type,Direction,Attachments,Body,Sender,Recipients,\"Message ID\"\n"
-        "2024-01-01T00:00:00Z,mms,in,sample.png,Hi,Alice,Bob,id1\n"
+        "2024-01-01T00:00:00Z,mms,in,a.jpg|b.jpg,Hi,Alice,Bob,id1\n"
     )
-    csv2 = (
-        "Date,Type,Direction,Attachments,Body,Sender,Recipients,\"Message ID\"\n"
-        "2024-01-02T00:00:00Z,sms,out,sample.png,Bye,Bob,Alice,id2\n"
-    )
-    (messages_dir / "20240101.csv").write_text(csv1)
-    (messages_dir / "20240102.csv").write_text(csv2)
+    (messages_dir / "20240101.csv").write_text(csv)
 
     compiled = tmp_path / "Compiled Attachments"
     records, _ = collect_attachments.collect_attachments(messages_dir / "attachments", compiled)
 
-    names = {r["File Name"] for r in records}
-    assert names == {"sample.png", "sample_1.png"}
+    names = sorted(r["File Name"] for r in records)
+    assert names == [
+        "Alice - 2024-01-01 00-00-00.jpg",
+        "Alice - 2024-01-01 00-00-00_1.jpg",
+    ]
 
-    senders = {r["Sender"] for r in records}
-    assert senders == {"Alice", "Bob"}
-
-    assert len(list(compiled.glob("*.png"))) == 2
+    assert len(list(compiled.glob("*.jpg"))) == 2


### PR DESCRIPTION
## Summary
- support contact name lookup during attachment collection
- rename copied attachments using sender and message date
- allow GUI to supply contacts file for attachment processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0a35246e883249d9f83736b78c346